### PR TITLE
Fixing undefined offset notice if fields are empty

### DIFF
--- a/Test/Case/View/CsvViewTest.php
+++ b/Test/Case/View/CsvViewTest.php
@@ -136,4 +136,42 @@ class CsvViewTest extends CakeTestCase {
 		$this->assertSame('text/csv', $Response->type());
 	}
 
+	public function testRenderViaExtractOptionalField() {
+		App::build(array(
+			'View' => realpath(dirname(__FILE__) . DS . '..' . DS . '..' . DS . 'test_app' . DS . 'View' . DS) . DS,
+		));
+		$Request = new CakeRequest();
+		$Response = new CakeResponse();
+		$Controller = new Controller($Request, $Response);
+		$Controller->name = $Controller->viewPath = 'Posts';
+
+		$data = array(
+			array(
+				'User' => array(
+					'username' => 'jose'
+				),
+				'Item' => array(
+					'name' => 'beach',
+				)
+			),
+			array(
+				'User' => array(
+					'username' => 'drew'
+				),
+				'Item' => array(
+					'name' => 'ball',
+					'type' => 'fun'
+				)
+			)
+		);
+		$_extract = array('User.username', 'Item.name', 'Item.type');
+		$Controller->set(array('user' => $data, '_extract' => $_extract));
+		$Controller->set(array('_serialize' => 'user'));
+		$View = new CsvView($Controller);
+		$output = $View->render(false);
+
+		$this->assertSame('jose,beach' . PHP_EOL . 'drew,ball,fun' . PHP_EOL, $output);
+		$this->assertSame('text/csv', $Response->type());
+	}
+
 }

--- a/View/CsvView.php
+++ b/View/CsvView.php
@@ -211,7 +211,9 @@ class CsvView extends View {
 					foreach ($extract as $e) {
 						list($path, $format) = $e;
 						$value = Hash::extract($_data, $path);
-						$values[] = sprintf($format, $value[0]);
+						if (isset($value[0])) {
+							$values[] = sprintf($format, $value[0]);
+						}
 					}
 					$this->_renderRow($values);
 				}


### PR DESCRIPTION
Using `$this->CsvView->quickExport($users);` with a table containing empty (not null) fields was giving me a PHP notice:

`Notice (8): Undefined offset: 0 [APP/Plugin/CsvView/View/CsvView.php, line 214]`

This seems to fix the notice, and exports work as expected. 
