### PR TITLE
Fix 'Undefined offset: 0' error for null values.

### DIFF
--- a/Test/Case/View/CsvViewTest.php
+++ b/Test/Case/View/CsvViewTest.php
@@ -136,4 +136,41 @@ class CsvViewTest extends CakeTestCase {
 		$this->assertSame('text/csv', $Response->type());
 	}
 
+	public function testRenderViaExtractWithNullValues() {
+		App::build(array(
+			'View' => realpath(dirname(__FILE__) . DS . '..' . DS . '..' . DS . 'test_app' . DS . 'View' . DS) . DS,
+		));
+		$Request = new CakeRequest();
+		$Response = new CakeResponse();
+		$Controller = new Controller($Request, $Response);
+		$Controller->name = $Controller->viewPath = 'Posts';
+
+		$data = array(
+			array(
+				'User' => array(
+					'username' => 'jose'
+				),
+				'Item' => array(
+					'name' => null,
+				)
+			),
+			array(
+				'User' => array(
+					'username' => 'drew'
+				),
+				'Item' => array(
+					'name' => 'ball',
+				)
+			)
+		);
+		$_extract = array('User.username', 'Item.name');
+		$Controller->set(array('user' => $data, '_extract' => $_extract));
+		$Controller->set(array('_serialize' => 'user'));
+		$View = new CsvView($Controller);
+		$output = $View->render(false);
+
+		$this->assertSame('jose,NULL' . PHP_EOL . 'drew,ball' . PHP_EOL, $output);
+		$this->assertSame('text/csv', $Response->type());
+	}
+
 }

--- a/View/CsvView.php
+++ b/View/CsvView.php
@@ -211,7 +211,11 @@ class CsvView extends View {
 					foreach ($extract as $e) {
 						list($path, $format) = $e;
 						$value = Hash::extract($_data, $path);
-						$values[] = sprintf($format, $value[0]);
+						if(isset($value[0])){
+							$values[] = sprintf($format, $value[0]);
+						} else {
+							$values[] = 'NULL';
+						}
 					}
 					$this->_renderRow($values);
 				}


### PR DESCRIPTION
When there were nulls in the data, and you were using $extract, it would give you an error:

Undefined offset: 0 [APP/Plugin/CsvView/View/CsvView.php, line 218]

This patch fixes that error, and shows null values as 'NULL' in the exported CSV. I debated wether to show null's as 'NULL' or just '' but I think 'NULL' is less ambiguous and avoids any chance of confusion. Happy to change if you think differently...

Signed-off-by: Joshua Paling joshua.paling@gmail.com
