### PR TITLE
handle null / missing columns properly

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -127,6 +127,10 @@ If you have complex model data, you can use the `$_extract` view variable to spe
 			$this->set(compact('posts', '_serialize', '_header', '_extract'));
 		}
 
+If your model data contains some null values or missing keys, you can use the `$_null` variable, just like you'd use `$_delimiter`, `$_eol`, and `$_enclosure`, to set how null values should be displayed in the CSV.
+
+`$_null` defaults to 'NULL'.
+
 You can use `Router::parseExtensions()` and the `RequestHandlerComponent` to automatically have the CsvView class switched in as follows:
 
 		// In your routes.php file:

--- a/Test/Case/View/CsvViewTest.php
+++ b/Test/Case/View/CsvViewTest.php
@@ -151,7 +151,7 @@ class CsvViewTest extends CakeTestCase {
 					'username' => 'jose'
 				),
 				'Item' => array(
-					'name' => 'beach',
+					'type' => 'beach',
 				)
 			),
 			array(
@@ -170,7 +170,7 @@ class CsvViewTest extends CakeTestCase {
 		$View = new CsvView($Controller);
 		$output = $View->render(false);
 
-		$this->assertSame('jose,beach' . PHP_EOL . 'drew,ball,fun' . PHP_EOL, $output);
+		$this->assertSame('jose,NULL,beach' . PHP_EOL . 'drew,ball,fun' . PHP_EOL, $output);
 		$this->assertSame('text/csv', $Response->type());
 	}
 

--- a/View/CsvView.php
+++ b/View/CsvView.php
@@ -158,7 +158,8 @@ class CsvView extends View {
 			'_serialize',
 			'_delimiter',
 			'_enclosure',
-			'_eol'
+			'_eol',
+			'_null'
 		);
 		foreach ($required as $viewVar) {
 			if (!isset($this->viewVars[$viewVar])) {
@@ -176,6 +177,10 @@ class CsvView extends View {
 
 		if ($this->viewVars['_eol'] === null) {
 			$this->viewVars['_eol'] = PHP_EOL;
+		}
+
+		if ($this->viewVars['_null'] === null) {
+			$this->viewVars['_null'] = 'NULL';
 		}
 
 		if ($this->viewVars['_extract'] !== null) {
@@ -213,6 +218,8 @@ class CsvView extends View {
 						$value = Hash::extract($_data, $path);
 						if (isset($value[0])) {
 							$values[] = sprintf($format, $value[0]);
+						} else {
+							$values[] = $this->viewVars['_null'];
 						}
 					}
 					$this->_renderRow($values);


### PR DESCRIPTION
Pull request #7 has an issue where rows that contain missing / null values will have their columns out of alignment with the data in other columns, and with the header/footer.

This resolves that issue by adding a string as a placeholder for null or missing columns. The value of this string can be changed via the $_null configuration option, and defaults to 'NULL'.

I think this code should also resolve issue #6.

Signed-off-by: Joshua Paling joshua.paling@gmail.com
