### PR TITLE
Browsers don't like CSV data with error 500

### DIFF
--- a/View/CsvView.php
+++ b/View/CsvView.php
@@ -76,6 +76,7 @@ class CsvView extends View {
 		parent::__construct($controller);
 		if (isset($controller->response) && $controller->response instanceof CakeResponse) {
 			$controller->response->type('csv');
+			$controller->response->statusCode(200);
 		}
 	}
 


### PR DESCRIPTION
This view is used when exceptions are thrown as well and try to serialize the data to a CSV type, so CSV data with a non 200 http code is very possible.  Browsers don't like CSV data with an error code of 500.
