### PR TITLE
Add _setSeperator flag to CsvView and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The `_eol` variable is the one used to generate newlines in the output.
 It is recommended to use the string representation of the newline character to avoid rendering invalid output.
 
 Some reader software incorrectly renders UTF-8 encoded files which do not contain byte order mark (BOM) byte sequence. The `_bom` variable is the one used to add byte order mark (BOM) byte sequence beginning of the generated CSV output stream. See [`Wikipedia article about byte order mark`](http://en.wikipedia.org/wiki/Byte_order_mark) for more information.
+
 The `_setSeparator` flag can be used to set the separator explicitly in the first line of the CSV. Some readers need this in order to display the CSV correctly.
 
 If you have complex model data, you can use the `$_extract` view variable to specify the individual paths for each record. This is an array of `Hash::extract()`-compatible syntax:

--- a/View/CsvView.php
+++ b/View/CsvView.php
@@ -162,7 +162,7 @@ class CsvView extends View {
 			'_eol',
 			'_null',
 			'_bom',
-		    '_setSeparator'
+			'_setSeparator'
 		);
 		foreach ($required as $viewVar) {
 			if (!isset($this->viewVars[$viewVar])) {


### PR DESCRIPTION
this is needed because some CSV-Editors (especially Microsoft Office) cant open the file if the location is set to a location where the currency seperator is equal to the seperator in the csv. The result is that the values are in one column (not split into columns).
The sep= indicator defines the seperator see german wikipedia [1]. I deactivated it by default so it wont bother users of other readers (ex. Libre Office).

[1] http://de.wikipedia.org/wiki/CSV_%28Dateiformat%29#Besonderheiten_beim_Import
