### PR TITLE
throw an error when _serialize not properly set.

### DIFF
--- a/View/CsvView.php
+++ b/View/CsvView.php
@@ -217,6 +217,13 @@ class CsvView extends View {
 		$serialize = $this->viewVars['_serialize'];
 
 		foreach ($serialize as $viewVar) {
+			
+			// check that the data is an array.. 
+			if (!is_array($this->viewVars[$viewVar])) {
+				// if it isn't, throw an error
+				throw new Exception($viewVar . "is not an array", 1);
+			}
+
 			foreach ($this->viewVars[$viewVar] as $_data) {
 				if ($extract === null) {
 					$this->_renderRow($_data);


### PR DESCRIPTION
prevents unhelpful error message when a CSV view is missing. Without the change you get the following:

Warning (2): Invalid argument supplied for foreach() [APP/Plugin/CsvView/View/CsvView.php, line 227]
Warning (2): Invalid argument supplied for foreach() [APP/Plugin/CsvView/View/CsvView.php, line 227]
Warning (2): Invalid argument supplied for foreach() [APP/Plugin/CsvView/View/CsvView.php, line 227]

when requesting a csv file for which there isn't a template.

Throwing this error allows CakePHP to report the real error.
