### PR TITLE
Added two new options for headers: includeClassname and humanReadable

### DIFF
--- a/Controller/Component/CsvViewComponent.php
+++ b/Controller/Component/CsvViewComponent.php
@@ -45,9 +45,9 @@ class CsvViewComponent extends Component {
  * Recursively searches a single row from the results of a model find('all') and
  * adds all unique Hash::extract() compatible paths to $extract
  *
+ * @param array &$extract reference to the array containing all unique paths
  * @param array $dataRow a single row from the results of a model find('all')
  * @param array $excludePaths an array of Hash::extract() compatible paths to be excluded
- * @param array $extract reference to the array containing all unique paths
  * @param string $parentPath Hash::extract() compatible string of all paths up until this point (for deep nested arrays)
  * @return void
  */
@@ -75,23 +75,42 @@ class CsvViewComponent extends Component {
  *
  * @param array $extract an array of Hash::extract() compatible paths
  * @param array $customHeaders array of 'Hash.Path' => 'Custom Title' pairs, to override default generated titles
+ * @param array $options an array of options:
+ *    'includeClassname' => if true, the class name will be included in the default generated titles,
+ *    'humanReadable' => if true, underscores in variable names will be replaced by spaces,
+ *    and the first character of each word will be uppercased 
  * @return array an array of user-friendly headers, matching the passed in $extract array
  */
-	public function prepareHeaderFromExtract($extract, $customHeaders = array()) {
+	public function prepareHeaderFromExtract($extract, $customHeaders = array(), $options = array()) {
+		$defaults = array('includeClassname' => true, 'humanReadable' => true);
+		$options += $defaults;
+
 		$header = array();
 		foreach ($extract as $fullPath) {
 			if (!empty($customHeaders[$fullPath])) {
 				$header[] = $customHeaders[$fullPath];
 			} else {
 				$pathParts = explode('.', $fullPath);
-				$model = $pathParts[count($pathParts) - 2];
-				$model = preg_replace('/(?<! )(?<!^)[A-Z]/', ' $0', $model);
 
 				$column = $pathParts[count($pathParts) - 1];
-				$column = str_replace('_', ' ', $column);
-				$column = ucwords($column);
 
-				$header[] = $model . ' ' . $column;
+				if ($options['humanReadable']) {
+					$column = str_replace('_', ' ', $column);
+					$column = ucwords($column);
+				}
+
+				if ($options['includeClassname']) {
+					$model = $pathParts[count($pathParts) - 2];
+
+					if ($options['humanReadable']) {
+						$model = preg_replace('/(?<! )(?<!^)[A-Z]/', ' $0', $model);
+						$header[] = $model . ' ' . $column;
+					} else {
+						$header[] = $model . '.' . $column;
+					}
+				} else {
+					$header[] = $column;
+				}
 			}
 		}
 
@@ -104,14 +123,26 @@ class CsvViewComponent extends Component {
  * @param array $data the results of a model find('all') call.
  * @param array $excludePaths an array of Hash::extract() compatible paths to be excluded
  * @param array $customHeaders array of 'Hash.Path' => 'Custom Title' pairs, to override default generated titles
- * @param boolean $includeHeader if true, a header will be included in the exported CSV.
+ * @param array $options an array of options:
+ *    'includeHeader' => if true, a header will be included in the exported CSV,
+ *    'includeClassname' => if true, the class name will be included in the default generated titles,
+ *    'humanReadable' => if true, underscores in variable names will be replaced by spaces,
+ *    and the first character of each word will be uppercased
  * @return void
  */
-	public function quickExport($data, $excludePaths = array(), $customHeaders = array(), $includeHeader = true) {
+	public function quickExport($data, $excludePaths = array(), $customHeaders = array(), $options = array()) {
+		// Maintain backwards compatiblity if someone passes a boolean includeHeader instead of an options array
+		if (!is_array($options)) {
+			$options = array('includeHeader' => (bool)$options);
+		}
+
+		$defaults = array('includeHeader' => true, 'includeClassname' => true, 'humanReadable' => true);
+		$options += $defaults;
+
 		$_serialize = 'data';
 		$_extract = $this->prepareExtractFromFindResults($data, $excludePaths);
-		if ($includeHeader) {
-			$_header = $this->prepareHeaderFromExtract($_extract, $customHeaders);
+		if ($options['includeHeader']) {
+			$_header = $this->prepareHeaderFromExtract($_extract, $customHeaders, $options);
 		}
 		$this->controller->viewClass = 'CsvView.Csv';
 		$this->controller->set(compact('data', '_serialize', '_header', '_extract'));

--- a/Test/Case/Controller/Component/CsvViewComponentTest.php
+++ b/Test/Case/Controller/Component/CsvViewComponentTest.php
@@ -61,6 +61,7 @@ class CsvViewComponentTest extends CakeTestCase {
 
 /**
  * Expected output of prepareExtractFromFindResults for $_exampleNested array above
+ *
  * @var array
  */
 	protected $_exampleExtract = array(
@@ -73,6 +74,7 @@ class CsvViewComponentTest extends CakeTestCase {
 
 /**
  * Expected output of prepareHeaderFromExtract for $_exampleExtract array above
+ *
  * @var array
  */
 	protected $_exampleHeader = array(
@@ -84,7 +86,48 @@ class CsvViewComponentTest extends CakeTestCase {
 	);
 
 /**
+ * Expected output of prepareHeaderFromExtract for $_exampleExtract array above with includeClassname=false
+ *
+ * @var array
+ */
+	protected $_exampleHeaderIncludeClassnameFalse = array(
+		'Name',
+		'Number of People', // overriding City.population
+		'Name',
+		'Name',
+		'Name',
+	);
+
+/**
+ * Expected output of prepareHeaderFromExtract for $_exampleExtract array above with humanReadable=false
+ *
+ * @var array
+ */
+	protected $_exampleHeaderHumanReadableFalse = array(
+		'City.name',
+		'Number of People', // overriding City.population
+		'State.name',
+		'Country.name',
+		'Continent.name',
+	);
+
+/**
+ * Expected output of prepareHeaderFromExtract for $_exampleExtract array above with includeClassname=false
+ * and humanReadable=false
+ *
+ * @var array
+ */
+	protected $_exampleHeaderIncludeClassnameFalseHumanReadableFalse = array(
+		'name',
+		'Number of People', // overriding City.population
+		'name',
+		'name',
+		'name',
+	);
+
+/**
  * Example $_extract array, with multi word columns / models included
+ *
  * @var array
  */
 	protected $_exampleExtract2 = array(
@@ -96,13 +139,51 @@ class CsvViewComponentTest extends CakeTestCase {
 
 /**
  * Expected output of prepareHeaderFromExtract for $_exampleExtract2 array above
+ *
  * @var array
  */
-	protected $__exampleHeader2 = array(
+	protected $_exampleHeader2 = array(
 		'City Population',
 		'My Custom Title', // overriding State.name
 		'Country Multi Word Column',
 		'Multi Word Model Column',
+	);
+
+/**
+ * Expected output of prepareHeaderFromExtract for $_exampleExtract2 array above with includeClassname=false
+ *
+ * @var array
+ */
+	protected $_exampleHeader2IncludeClassnameFalse = array(
+		'Population',
+		'My Custom Title', // overriding State.name
+		'Multi Word Column',
+		'Column',
+	);
+
+/**
+ * Expected output of prepareHeaderFromExtract for $_exampleExtract2 array above with humanReadable=false
+ *
+ * @var array
+ */
+	protected $_exampleHeader2HumanReadableFalse = array(
+		'City.population',
+		'My Custom Title', // overriding State.name
+		'Country.multi_word_column',
+		'MultiWordModel.column',
+	);
+
+/**
+ * Expected output of prepareHeaderFromExtract for $_exampleExtract2 array above with includeClassname=false
+ * and humanReadable=false
+ *
+ * @var array
+ */
+	protected $_exampleHeader2IncludeClassnameFalseHumanReadableFalse = array(
+		'population',
+		'My Custom Title', // overriding State.name
+		'multi_word_column',
+		'column',
 	);
 
 /**
@@ -129,7 +210,7 @@ class CsvViewComponentTest extends CakeTestCase {
 	public function testPrepareExtractFromFindResults() {
 		$excludePaths = array('State.excluded_column');
 		$extract = $this->CsvViewComponent->prepareExtractFromFindResults($this->_exampleNested, $excludePaths);
-		$this->assertEqual($this->_exampleExtract, $extract);
+		$this->assertEquals($this->_exampleExtract, $extract);
 	}
 
 /**
@@ -140,7 +221,25 @@ class CsvViewComponentTest extends CakeTestCase {
 	public function testPrepareHeaderFromExtract() {
 		$customHeaders = array('State.name' => 'My Custom Title');
 		$header = $this->CsvViewComponent->prepareHeaderFromExtract($this->_exampleExtract2, $customHeaders);
-		$this->assertEqual($this->__exampleHeader2, $header);
+		$this->assertEquals($this->_exampleHeader2, $header);
+	}
+
+/**
+ * testPrepareHeaderFromExtractWithOptions method
+ *
+ * @return void
+ */
+	public function testPrepareHeaderFromExtractWithOptions() {
+		$customHeaders = array('State.name' => 'My Custom Title');
+
+		$header = $this->CsvViewComponent->prepareHeaderFromExtract($this->_exampleExtract2, $customHeaders, array('includeClassname' => false));
+		$this->assertEquals($this->_exampleHeader2IncludeClassnameFalse, $header);
+
+		$header = $this->CsvViewComponent->prepareHeaderFromExtract($this->_exampleExtract2, $customHeaders, array('humanReadable' => false));
+		$this->assertEquals($this->_exampleHeader2HumanReadableFalse, $header);
+
+		$header = $this->CsvViewComponent->prepareHeaderFromExtract($this->_exampleExtract2, $customHeaders, array('includeClassname' => false, 'humanReadable' => false));
+		$this->assertEquals($this->_exampleHeader2IncludeClassnameFalseHumanReadableFalse, $header);
 	}
 
 /**
@@ -153,11 +252,11 @@ class CsvViewComponentTest extends CakeTestCase {
 		$customHeaders = array('City.population' => 'Number of People');
 		$header = $this->CsvViewComponent->quickExport($this->_exampleNested, $excludePaths, $customHeaders);
 
-		$this->assertEqual($this->_exampleNested, $this->Controller->viewVars['data']);
-		$this->assertEqual('data', $this->Controller->viewVars['_serialize']);
-		$this->assertEqual($this->_exampleExtract, $this->Controller->viewVars['_extract']);
-		$this->assertEqual($this->_exampleHeader, $this->Controller->viewVars['_header']);
-		$this->assertEqual('CsvView.Csv', $this->Controller->viewClass);
+		$this->assertEquals($this->_exampleNested, $this->Controller->viewVars['data']);
+		$this->assertEquals('data', $this->Controller->viewVars['_serialize']);
+		$this->assertEquals($this->_exampleExtract, $this->Controller->viewVars['_extract']);
+		$this->assertEquals($this->_exampleHeader, $this->Controller->viewVars['_header']);
+		$this->assertEquals('CsvView.Csv', $this->Controller->viewClass);
 	}
 
 /**
@@ -168,14 +267,51 @@ class CsvViewComponentTest extends CakeTestCase {
 	public function testQuickExportNoHeaders() {
 		$excludePaths = array('State.excluded_column');
 		$customHeaders = array('City.population' => 'Number of People');
-		$header = $this->CsvViewComponent->quickExport($this->_exampleNested, $excludePaths, $customHeaders, false);
+		$header = $this->CsvViewComponent->quickExport($this->_exampleNested, $excludePaths, $customHeaders, array('includeHeader' => false));
 
-		$this->assertEqual($this->_exampleNested, $this->Controller->viewVars['data']);
-		$this->assertEqual('data', $this->Controller->viewVars['_serialize']);
-		$this->assertEqual($this->_exampleExtract, $this->Controller->viewVars['_extract']);
+		$this->assertEquals($this->_exampleNested, $this->Controller->viewVars['data']);
+		$this->assertEquals('data', $this->Controller->viewVars['_serialize']);
+		$this->assertEquals($this->_exampleExtract, $this->Controller->viewVars['_extract']);
 		$hasHeader = (empty($this->Controller->viewVars['_header'])) ? false : true;
 		$this->assertFalse($hasHeader);
-		$this->assertEqual('CsvView.Csv', $this->Controller->viewClass);
+		$this->assertEquals('CsvView.Csv', $this->Controller->viewClass);
+	}
+
+/**
+ * testQuickExportNoHeadersBC method (tests backwards compatibility)
+ *
+ * @return void
+ */
+	public function testQuickExportNoHeadersBC() {
+		$excludePaths = array('State.excluded_column');
+		$customHeaders = array('City.population' => 'Number of People');
+		$header = $this->CsvViewComponent->quickExport($this->_exampleNested, $excludePaths, $customHeaders, false);
+
+		$this->assertEquals($this->_exampleNested, $this->Controller->viewVars['data']);
+		$this->assertEquals('data', $this->Controller->viewVars['_serialize']);
+		$this->assertEquals($this->_exampleExtract, $this->Controller->viewVars['_extract']);
+		$hasHeader = (empty($this->Controller->viewVars['_header'])) ? false : true;
+		$this->assertFalse($hasHeader);
+		$this->assertEquals('CsvView.Csv', $this->Controller->viewClass);
+	}
+
+/**
+ * testQuickExportNoHeadersWithOptions method
+ *
+ * @return void
+ */
+	public function testQuickExportWithOptions() {
+		$excludePaths = array('State.excluded_column');
+		$customHeaders = array('City.population' => 'Number of People');
+
+		$header = $this->CsvViewComponent->quickExport($this->_exampleNested, $excludePaths, $customHeaders, array('includeClassname' => false));
+		$this->assertEquals($this->_exampleHeaderIncludeClassnameFalse, $this->Controller->viewVars['_header']);
+
+		$header = $this->CsvViewComponent->quickExport($this->_exampleNested, $excludePaths, $customHeaders, array('humanReadable' => false));
+		$this->assertEquals($this->_exampleHeaderHumanReadableFalse, $this->Controller->viewVars['_header']);
+
+		$header = $this->CsvViewComponent->quickExport($this->_exampleNested, $excludePaths, $customHeaders, array('includeClassname' => false, 'humanReadable' => false));
+		$this->assertEquals($this->_exampleHeaderIncludeClassnameFalseHumanReadableFalse, $this->Controller->viewVars['_header']);
 	}
 
 /**

--- a/View/CsvView.php
+++ b/View/CsvView.php
@@ -70,7 +70,7 @@ class CsvView extends View {
 /**
  * Constructor
  *
- * @param Controller $controller
+ * @param Controller $controller The currently active Controller.
  */
 	public function __construct(Controller $controller = null) {
 		parent::__construct($controller);


### PR DESCRIPTION
I really like this CakePHP plugin, but I needed a more flexible option to export a CSV that was not intended to be read by humans, but intended to be parsed by another program.

To achieve that, I added two new options for the default headers output by CsvViewComponent.
## New Options
- $includeClassname -- if true, the class name will be included in the default generated titles
- $humanReadable -- if true, underscores in variable names will be replaced by spaces, and the first character of each word will be uppercased
## Results
- If both options are set to true, column "user_id" from model "Post" will render as "Post User Id," just as it does now.
- If $includeClassname=true and $humanReadable=false, it will render as "Post user_id"
- If $includeClassname=false and $humanReadable=true, it will render as "User Id"
- If both are false, it will render as "user_id"

I originally made these modifications for my own use, but I figured that others might also find them useful.  Therefore, I made both options true by default, which makes these changes backwards compatible -- existing programs will require no modifications.

If you approve this Pull Request, I will also update the documentation.

Thanks josegonzalez!
