### PR TITLE
throw an error when _serialize not properly set.

### DIFF
--- a/View/CsvView.php
+++ b/View/CsvView.php
@@ -216,8 +216,8 @@ class CsvView extends View {
 /**
  * Renders the body of the data to the csv
  *
- * @throws Exception
  * @return void
+ * @throws Exception
  **/
 	protected function _renderContent() {
 		$extract = $this->viewVars['_extract'];
@@ -225,9 +225,7 @@ class CsvView extends View {
 
 		foreach ($serialize as $viewVar) {
 
-			// check that the data is an array..
-			if (!is_array($this->viewVars[$viewVar])) {
-				// if it isn't, throw an error
+			if (! is_array($this->viewVars[$viewVar])) {
 				throw new Exception($viewVar . "is not an array", 1);
 			}
 

--- a/View/CsvView.php
+++ b/View/CsvView.php
@@ -225,8 +225,8 @@ class CsvView extends View {
 
 		foreach ($serialize as $viewVar) {
 
-			if (! is_array($this->viewVars[$viewVar])) {
-				throw new Exception($viewVar . "is not an array", 1);
+			if (!is_array($this->viewVars[$viewVar])) {
+				throw new Exception($viewVar . " is not an array", 1);
 			}
 
 			foreach ($this->viewVars[$viewVar] as $_data) {

--- a/View/CsvView.php
+++ b/View/CsvView.php
@@ -216,6 +216,7 @@ class CsvView extends View {
 /**
  * Renders the body of the data to the csv
  *
+ * @throws Exception
  * @return void
  **/
 	protected function _renderContent() {
@@ -223,6 +224,13 @@ class CsvView extends View {
 		$serialize = $this->viewVars['_serialize'];
 
 		foreach ($serialize as $viewVar) {
+
+			// check that the data is an array..
+			if (!is_array($this->viewVars[$viewVar])) {
+				// if it isn't, throw an error
+				throw new Exception($viewVar . "is not an array", 1);
+			}
+
 			foreach ($this->viewVars[$viewVar] as $_data) {
 				if ($extract === null) {
 					$this->_renderRow($_data);


### PR DESCRIPTION
like pull request's @asmt3 with test fixes :

    prevents unhelpful error message when a CSV view is missing. Without the change you get the following:

    Warning (2): Invalid argument supplied for foreach() [APP/Plugin/CsvView/View/CsvView.php, line 227]
    Warning (2): Invalid argument supplied for foreach() [APP/Plugin/CsvView/View/CsvView.php, line 227]
    Warning (2): Invalid argument supplied for foreach() [APP/Plugin/CsvView/View/CsvView.php, line 227]

    when requesting a csv file for which there isn't a template.

    Throwing this error allows CakePHP to report the real error.