### PR TITLE
Encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,18 @@ public function export() {
 	$this->set(compact('posts', '_serialize');
 }
 ```
+#### Setting a different encoding to the file
+
+if you need to have a different encoding in you csv file you have to set the encoding of your data
+you are passing to the view and also set the encoding you want for the csv file.
+This can be done by using `_dataEncoding` and `_csvEncoding`:
+
+The defaults are:
+ 
+* `_dataEncoding`: `UTF-8`
+* `_csvEncoding`: `UTF-8`
+
+** Only if those two variable are different your data will be converted to another encoding.
 
 #### Setting the downloaded file name
 By default, the downloaded file will be named after the last segment of the URL

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -98,7 +98,9 @@ class CsvView extends View
         '_eol',
         '_null',
         '_bom',
-        '_setSeparator'
+        '_setSeparator',
+        '_csvEncoding',
+        '_dataEncoding'
     ];
 
     /**

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -242,6 +242,14 @@ class CsvView extends View
             $this->viewVars['_setSeparator'] = false;
         }
 
+        if ($this->viewVars['_dataEncoding'] === null) {
+            $this->viewVars['_dataEncoding'] = 'UTF-8';
+        }
+
+        if ($this->viewVars['_csvEncoding'] === null) {
+            $this->viewVars['_csvEncoding'] = 'UTF-8';
+        }
+
         if ($this->viewVars['_extract'] !== null) {
             $this->viewVars['_extract'] = (array)$this->viewVars['_extract'];
             foreach ($this->viewVars['_extract'] as $i => $extract) {
@@ -371,6 +379,12 @@ class CsvView extends View
         $eol = $this->viewVars['_eol'];
         if ($eol !== "\n") {
             $csv = str_replace("\n", $eol, $csv);
+        }
+
+        $dataEncoding = $this->viewVars['_dataEncoding'];
+        $csvEncoding = $this->viewVars['_csvEncoding'];
+        if ($dataEncoding != $csvEncoding) {
+            $csv = iconv($dataEncoding, $csvEncoding, $csv);
         }
 
         return $csv;

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -385,7 +385,7 @@ class CsvView extends View
 
         $dataEncoding = $this->viewVars['_dataEncoding'];
         $csvEncoding = $this->viewVars['_csvEncoding'];
-        if ($dataEncoding != $csvEncoding) {
+        if ($dataEncoding !== $csvEncoding) {
             $csv = iconv($dataEncoding, $csvEncoding, $csv);
         }
 


### PR DESCRIPTION
I am from Greece. So most of my data are in Greek language inside my DB and they are stored as UTF-8. The data can be viewed normally if you open the with a text editor like notepad++ but If I need them to be viewed with MS Excel they will be scrambled.

This way you can add support for different encoding.
