### PR TITLE
Fix CakePHP date(time) object values to be not destroyed but exported…

### DIFF
--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -298,11 +298,9 @@ class CsvView extends View
                     $values = [];
                     foreach ($extract as $e) {
                         list($path, $format) = $e;
-                        $value = Hash::extract($_data, $path);
-                        if (isset($value[0])) {
-                            $values[] = sprintf($format, $value[0]);
-                        } elseif (isset($value['date'])) {
-                            $values[] = $value['date'];
+                        $value = Hash::get($_data, $path);
+                        if (isset($value)) {
+                            $values[] = sprintf($format, $value);
                         } else {
                             $values[] = $this->viewVars['_null'];
                         }

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -301,6 +301,8 @@ class CsvView extends View
                         $value = Hash::extract($_data, $path);
                         if (isset($value[0])) {
                             $values[] = sprintf($format, $value[0]);
+                        } elseif (isset($value['date'])) {
+                            $values[] = $value['date'];
                         } else {
                             $values[] = $this->viewVars['_null'];
                         }

--- a/tests/TestCase/View/CsvViewTest.php
+++ b/tests/TestCase/View/CsvViewTest.php
@@ -19,6 +19,8 @@ class CsvViewTest extends TestCase
 
     public function setUp()
     {
+        Time::setToStringFormat('yyyy-MM-dd HH:mm:ss');
+
         $this->request = new Request();
         $this->response = new Response();
 

--- a/tests/TestCase/View/CsvViewTest.php
+++ b/tests/TestCase/View/CsvViewTest.php
@@ -2,6 +2,7 @@
 namespace CsvView\Test\TestCase\View;
 
 use Cake\Controller\Controller;
+use Cake\I18n\Time;
 use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\ORM\TableRegistry;
@@ -121,7 +122,8 @@ class CsvViewTest extends TestCase
         $data = [
             [
                 'User' => [
-                    'username' => 'jose'
+                    'username' => 'jose',
+                    'created' => new Time('2010-01-05')
                 ],
                 'Item' => [
                     'name' => 'beach',
@@ -129,19 +131,20 @@ class CsvViewTest extends TestCase
             ],
             [
                 'User' => [
-                    'username' => 'drew'
+                    'username' => 'drew',
+                    'created' => null
                 ],
                 'Item' => [
                     'name' => 'ball',
                 ]
             ]
         ];
-        $_extract = ['User.username', 'Item.name'];
+        $_extract = ['User.username', 'User.created', 'Item.name'];
         $this->view->set(['user' => $data, '_extract' => $_extract]);
         $this->view->set(['_serialize' => 'user']);
         $output = $this->view->render(false);
 
-        $this->assertSame('jose,beach' . PHP_EOL . 'drew,ball' . PHP_EOL, $output);
+        $this->assertSame('jose,"2010-01-05 00:00:00",beach' . PHP_EOL . 'drew,NULL,ball' . PHP_EOL, $output);
         $this->assertSame('text/csv', $this->response->type());
     }
 


### PR DESCRIPTION
… again.

Resolves https://github.com/FriendsOfCake/cakephp-csvview/issues/46

The main problem is Hash::extract() and that it converts the date into an array upon lookup.
The isset($x[0]) check cannot work on an array that is

    [
        'date' => ....,
        ....
    ]

So this fixes it but for every other object it will most likely fail, Maybe the array transformation should not be happening for objects in Hash::extract()? Or there should be a to string cast instead.
Either way, this PR at least now solves our specific issue at hand.

I tested it in my sandbox:
http://sandbox3.dereuromark.de/sandbox/csv/pagination
Currently the datetime fields would be indeed just gone, but as soon as this is merged, I will update the examples and you can see that it works as expected.