### PR TITLE
Fix NULL default value and fix custom null bug

### DIFF
--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -234,7 +234,7 @@ class CsvView extends View
         }
 
         if ($this->viewVars['_null'] === null) {
-            $this->viewVars['_null'] = 'NULL';
+            $this->viewVars['_null'] = '';
         }
 
         if ($this->viewVars['_bom'] === null) {
@@ -338,7 +338,7 @@ class CsvView extends View
      * returning it's contents
      *
      * @param array $row Row data
-     * @return mixed string with the row in csv-syntax, false on fputscv failure
+     * @return string|false String with the row in csv-syntax, false on fputscv failure
      */
     protected function _generateRow($row = null)
     {
@@ -359,6 +359,14 @@ class CsvView extends View
 
         if ($row === false || $row === null) {
             return '';
+        }
+
+        if ($this->viewVars['_null'] !== '') {
+            foreach ($row as &$field) {
+                if ($field === null) {
+                    $field = $this->viewVars['_null'];
+                }
+            }
         }
 
         $delimiter = $this->viewVars['_delimiter'];

--- a/tests/TestCase/View/CsvViewTest.php
+++ b/tests/TestCase/View/CsvViewTest.php
@@ -146,7 +146,7 @@ class CsvViewTest extends TestCase
         $this->view->set(['_serialize' => 'user']);
         $output = $this->view->render(false);
 
-        $this->assertSame('jose,"2010-01-05 00:00:00",beach' . PHP_EOL . 'drew,NULL,ball' . PHP_EOL, $output);
+        $this->assertSame('jose,"2010-01-05 00:00:00",beach' . PHP_EOL . 'drew,,ball' . PHP_EOL, $output);
         $this->assertSame('text/csv', $this->response->type());
     }
 
@@ -183,7 +183,7 @@ class CsvViewTest extends TestCase
         $this->view->set(['_serialize' => 'user']);
         $output = $this->view->render(false);
 
-        $this->assertSame('jose,NULL,beach' . PHP_EOL . 'drew,ball,fun' . PHP_EOL, $output);
+        $this->assertSame('jose,,beach' . PHP_EOL . 'drew,ball,fun' . PHP_EOL, $output);
         $this->assertSame('text/csv', $this->response->type());
     }
 
@@ -230,7 +230,7 @@ class CsvViewTest extends TestCase
         $output = $this->view->render(false);
 
         $expected = <<<CSV
-José,NULL,äöü
+José,,äöü
 "Including,Comma","Containing""char",Containing'char
 "Some Space","A
 Newline","A\tTab"
@@ -291,6 +291,29 @@ CSV;
             $this->assertSame($expected, $output);
             $this->assertSame('text/csv', $this->response->type());
         }
+    }
+
+    /**
+     * Test render with a custom NULL option.
+     *
+     * @return void
+     */
+    public function testRenderWithCustomNull()
+    {
+        $data = [
+            ['a', 'b', 'c'],
+            [1, 2, null],
+            ['you', null, 'me'],
+        ];
+        $_serialize = 'data';
+        $this->view->set('data', $data);
+        $this->view->set(['_serialize' => 'data']);
+        $this->view->viewVars['_null'] = 'NULL';
+        $this->view->viewVars['_eol'] = '~';
+        $output = $this->view->render(false);
+
+        $this->assertSame('a,b,c~1,2,NULL~you,NULL,me~', $output);
+        $this->assertSame('text/csv', $this->response->type());
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/FriendsOfCake/cakephp-csvview/issues/56

Also fixes a bug that custom _null option was not respected for _generateRow() part.

Requires a new 2.4 release (or more correct a 3.0 one) with a note about the changed default value for NULL rows.