### PR TITLE
Add _extension variable to support mbstring extension

### DIFF
--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -83,6 +83,9 @@ class CsvView extends View
      */
     protected $_resetStaticVariables = false;
 
+    const EXTENSION_ICONV = 'iconv';
+    const EXTENSION_MBSTRING = 'mbstring';
+
     /**
      * List of special view vars.
      *
@@ -101,7 +104,8 @@ class CsvView extends View
         '_bom',
         '_setSeparator',
         '_csvEncoding',
-        '_dataEncoding'
+        '_dataEncoding',
+        '_extension'
     ];
 
     /**
@@ -253,6 +257,10 @@ class CsvView extends View
             $this->viewVars['_csvEncoding'] = 'UTF-8';
         }
 
+        if ($this->viewVars['_extension'] === null) {
+            $this->viewVars['_extension'] = self::EXTENSION_ICONV;
+        }
+
         if ($this->viewVars['_extract'] !== null) {
             $this->viewVars['_extract'] = (array)$this->viewVars['_extract'];
             foreach ($this->viewVars['_extract'] as $i => $extract) {
@@ -400,7 +408,12 @@ class CsvView extends View
         $dataEncoding = $this->viewVars['_dataEncoding'];
         $csvEncoding = $this->viewVars['_csvEncoding'];
         if ($dataEncoding !== $csvEncoding) {
-            $csv = iconv($dataEncoding, $csvEncoding, $csv);
+            $extension = $this->viewVars['_extension'];
+            if ($extension === self::EXTENSION_ICONV) {
+                $csv = iconv($dataEncoding, $csvEncoding, $csv);
+            } elseif ($extension === self::EXTENSION_MBSTRING) {
+                $csv = mb_convert_encoding($csv, $csvEncoding, $dataEncoding);
+            }
         }
 
         return $csv;

--- a/tests/TestCase/View/CsvViewTest.php
+++ b/tests/TestCase/View/CsvViewTest.php
@@ -91,6 +91,62 @@ class CsvViewTest extends TestCase
     }
 
     /**
+     * Test render with a custom encoding.
+     *
+     * @return void
+     */
+    public function testRenderWithCustomEncoding()
+    {
+        $data = [
+            ['a', 'b', 'c'],
+            [1, 2, 3],
+            ['あなた', 'と', '私'],
+        ];
+        $_serialize = 'data';
+        $this->view->set('data', $data);
+        $this->view->set(['_serialize' => 'data']);
+        $this->view->viewVars['_dataEncoding'] = 'UTF-8';
+        $this->view->viewVars['_csvEncoding'] = 'SJIS';
+        $output = $this->view->render(false);
+
+        $expected = iconv('UTF-8', 'SJIS', 'a,b,c' . PHP_EOL . '1,2,3' . PHP_EOL . 'あなた,と,私' . PHP_EOL);
+
+        $this->assertSame($expected, $output);
+        $this->assertSame('text/csv', $this->response->type());
+    }
+
+    /**
+     * Test render with mbstring extension.
+     *
+     * @return void
+     */
+    public function testRenderWithMbstring()
+    {
+        if (!extension_loaded('mbstring')) {
+            $this->markTestSkipped(
+                'The mbstring extension is not available.'
+            );
+        }
+        $data = [
+            ['a', 'b', 'c'],
+            [1, 2, 3],
+            ['あなた', 'と', '私'],
+        ];
+        $_serialize = 'data';
+        $this->view->set('data', $data);
+        $this->view->set(['_serialize' => 'data']);
+        $this->view->viewVars['_dataEncoding'] = 'UTF-8';
+        $this->view->viewVars['_csvEncoding'] = 'SJIS';
+        $this->view->viewVars['_extension'] = 'mbstring';
+        $output = $this->view->render(false);
+
+        $expected = mb_convert_encoding('a,b,c' . PHP_EOL . '1,2,3' . PHP_EOL . 'あなた,と,私' . PHP_EOL, 'SJIS', 'UTF-8');
+
+        $this->assertSame($expected, $output);
+        $this->assertSame('text/csv', $this->response->type());
+    }
+
+    /**
      * testRenderWithView method
      *
      * @return void


### PR DESCRIPTION
Hi!
I'm from Japan.  I use `mbstring` extension instead of `iconv`, because I need [mb_convert_kana](http://php.net/manual/en/function.mb-convert-kana.php), [mb_strlen](http://php.net/manual/en/function.mb-strlen.php) to manage Japanese language.

So, I add `_extension` variable to change extension ( you can add [`intl`](http://php.net/manual/en/uconverter.convert.php) in the future ).

