### PR TITLE
Extract callable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-#This Travis config template file was taken from https://github.com/FriendsOfCake/travis
 language: php
 
 php:
+  - 7.0
   - 5.4
   - 5.5
   - 5.6
@@ -14,26 +14,26 @@ matrix:
   fast_finish: true
 
   include:
-  - php: 5.4
+  - php: 7.0
     env: PHPCS=1 DEFAULT=0
 
-  - php: 5.4
-    env: COVERALLS=1 DEFAULT=0
-
 install:
+  - if [[ $TRAVIS_PHP_VERSION != 7.* ]]; then phpenv config-rm xdebug.ini; fi
+
   - composer self-update
-  - composer install --prefer-dist --no-interaction --dev
+  - composer install --prefer-dist --no-interaction
 
 before_script:
-  - sh -c "if [ '$PHPCS' = '1' ]; then composer require cakephp/cakephp-codesniffer:dev-master; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:1.*; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
+  - if [[ $PHPCS = 1 ]]; then composer require cakephp/cakephp-codesniffer:~2.1; fi
 
 script:
-  - sh -c "if [ '$DEFAULT' = '1' ]; then phpunit --stderr; fi"
-  - sh -c "if [ '$PHPCS' = '1' ]; then ./vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -c .coveralls.yml -v; fi"
+  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.* ]]; then export CODECOVERAGE=1; phpunit --coverage-clover=clover.xml; fi
+  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION != 7.* ]]; then phpunit; fi
+
+  - if [[ $PHPCS = 1 ]]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi
+
+after_success:
+  - if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.* ]]; then bash <(curl -s https://codecov.io/bash); fi
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://img.shields.io/travis/FriendsOfCake/cakephp-csvview/master.svg?style=flat-square)](https://travis-ci.org/FriendsOfCake/cakephp-csvview)
-[![Coverage Status](https://img.shields.io/coveralls/FriendsOfCake/cakephp-csvview.svg?style=flat-square)](https://coveralls.io/r/FriendsOfCake/cakephp-csvview?branch=master)
+[![Coverage Status](https://img.shields.io/codecov/c/github/FriendsOfCake/cakephp-csvview.svg?style=flat-square)](https://codecov.io/gh/FriendsOfCake/cakephp-csvview)
 [![Total Downloads](https://img.shields.io/packagist/dt/friendsofcake/cakephp-csvview.svg?style=flat-square)](https://packagist.org/packages/friendsofcake/cakephp-csvview)
 [![Latest Stable Version](https://img.shields.io/packagist/v/friendsofcake/cakephp-csvview.svg?style=flat-square)](https://packagist.org/packages/friendsofcake/cakephp-csvview)
 

--- a/README.md
+++ b/README.md
@@ -39,16 +39,17 @@ Load the plugin in your app's `config/bootstrap.php` file:
 To export a flat array as a CSV, one could write the following code:
 
 ```php
-public function export() {
-	$data = [
-		['a', 'b', 'c'],
-		[1, 2, 3],
-		['you', 'and', 'me'],
-	];
-	$_serialize = 'data';
+public function export()
+{
+    $data = [
+        ['a', 'b', 'c'],
+        [1, 2, 3],
+        ['you', 'and', 'me'],
+    ];
+    $_serialize = 'data';
 
-	$this->viewBuilder()->className('CsvView.Csv');
-	$this->set(compact('data', '_serialize'));
+    $this->viewBuilder()->className('CsvView.Csv');
+    $this->set(compact('data', '_serialize'));
 }
 ```
 
@@ -58,15 +59,16 @@ All variables that are to be included in the csv must be specified in the
 It is possible to have multiple variables in the csv output:
 
 ```php
-public function export() {
-	$data = [['a', 'b', 'c']];
-	$data_two = [[1, 2, 3]];
-	$data_three = [['you', 'and', 'me']];
+public function export()
+{
+    $data = [['a', 'b', 'c']];
+    $data_two = [[1, 2, 3]];
+    $data_three = [['you', 'and', 'me']];
 
-	$_serialize = ['data', 'data_two', 'data_three'];
+    $_serialize = ['data', 'data_two', 'data_three'];
 
-	$this->viewBuilder()->className('CsvView.Csv');
-	$this->set(compact('data', 'data_two', 'data_three', '_serialize'));
+    $this->viewBuilder()->className('CsvView.Csv');
+    $this->set(compact('data', 'data_two', 'data_three', '_serialize'));
 }
 ```
 
@@ -74,19 +76,20 @@ If you want headers or footers in your CSV output, you can specify either a
 `$_header` or `$_footer` view variable. Both are completely optional:
 
 ```php
-public function export() {
-	$data = [
-		['a', 'b', 'c'],
-		[1, 2, 3],
-		['you', 'and', 'me'],
-	];
+public function export()
+{
+    $data = [
+        ['a', 'b', 'c'],
+        [1, 2, 3],
+        ['you', 'and', 'me'],
+    ];
 
-	$_serialize = 'data';
-	$_header = ['Column 1', 'Column 2', 'Column 3'];
-	$_footer = ['Totals', '400', '$3000'];
+    $_serialize = 'data';
+    $_header = ['Column 1', 'Column 2', 'Column 3'];
+    $_footer = ['Totals', '400', '$3000'];
 
-	$this->viewBuilder()->className('CsvView.Csv');
-	$this->set(compact('data', '_serialize', '_header', '_footer'));
+    $this->viewBuilder()->className('CsvView.Csv');
+    $this->set(compact('data', '_serialize', '_header', '_footer'));
 }
 ```
 
@@ -95,22 +98,23 @@ byte order mark (BOM) sequence using `$_delimiter`, `$_eol`, `$_newline`,
 `$_enclosure` and `$_bom` respectively:
 
 ```php
-public function export() {
-	$data = [
-		['a', 'b', 'c'],
-		[1, 2, 3],
-		['you', 'and', 'me'],
-	];
+public function export()
+{
+    $data = [
+        ['a', 'b', 'c'],
+        [1, 2, 3],
+        ['you', 'and', 'me'],
+    ];
 
-	$_serialize = 'data';
-	$_delimiter = chr(9); //tab
-	$_enclosure = '"';
-	$_newline = '\r\n';
-	$_eol = '~';
-	$_bom = true;
+    $_serialize = 'data';
+    $_delimiter = chr(9); //tab
+    $_enclosure = '"';
+    $_newline = '\r\n';
+    $_eol = '~';
+    $_bom = true;
 
-	$this->viewBuilder()->className('CsvView.Csv');
-	$this->set(compact('data', '_serialize', '_delimiter', '_enclosure', '_newline', '_eol', '_bom'));
+    $this->viewBuilder()->className('CsvView.Csv');
+    $this->set(compact('data', '_serialize', '_delimiter', '_enclosure', '_newline', '_eol', '_bom'));
 }
 ```
 
@@ -138,18 +142,25 @@ The `_setSeparator` flag can be used to set the separator explicitly in the
 first line of the CSV. Some readers need this in order to display the CSV correctly.
 
 If you have complex model data, you can use the `$_extract` view variable to
-specify the individual paths for each record. This is an array of
-[`Hash::extract()`-compatible syntax](http://book.cakephp.org/3.0/en/core-libraries/hash.html):
+specify the individual [`Hash::extract()`-compatible](http://book.cakephp.org/3.0/en/core-libraries/hash.html) paths
+or a callable for each record:
 
 ```php
-public function export() {
-	$posts = $this->Post->find('all');
-	$_serialize = 'posts';
-	$_header = ['Post ID', 'Title', 'Created'];
-	$_extract = ['id', 'title', 'created'];
+public function export()
+{
+    $posts = $this->Post->find('all');
+    $_serialize = 'posts';
+    $_header = ['Post ID', 'Title', 'Created'];
+    $_extract = [
+        'id',
+        function ($row) {
+            return $row['title];
+        },
+        'created'
+    ];
 
-	$this->viewClass = 'CsvView.Csv';
-	$this->set(compact('posts', '_serialize', '_header', '_extract'));
+    $this->viewBuilder->className('CsvView.Csv');
+    $this->set(compact('posts', '_serialize', '_header', '_extract'));
 }
 ```
 
@@ -168,22 +179,23 @@ Router::extensions('csv');
 
 // In your controller:
 public $components = [
-	'RequestHandler' => [
-		'viewClassMap' => ['csv' => 'CsvView.Csv']
-	]
+    'RequestHandler' => [
+        'viewClassMap' => ['csv' => 'CsvView.Csv']
+    ]
 ];
 
-public function export() {
-	$posts = $this->Post->find('all');
-	$this->set(compact('post'));
+public function export()
+{
+    $posts = $this->Post->find('all');
+    $this->set(compact('post'));
 
-	if ($this->request->params['_ext'] === 'csv') {
-		$_serialize = 'posts';
-		$_header = array('Post ID', 'Title', 'Created');
-		$_extract = array('id', 'title', 'created');
+    if ($this->request->params['_ext'] === 'csv') {
+        $_serialize = 'posts';
+        $_header = array('Post ID', 'Title', 'Created');
+        $_extract = array('id', 'title', 'created');
 
-		$this->set(compact('_serialize', '_header', '_extract'));
-	}
+        $this->set(compact('_serialize', '_header', '_extract'));
+    }
 }
 ```
 
@@ -195,11 +207,12 @@ The view files will be located in the `csv` subdirectory of your current control
 
 ```php
 // View used will be in src/Template/Posts/csv/export.ctp
-public function export() {
-	$posts = $this->Post->find('all');
-	$_serialize = null;
-	$this->viewBuilder()->className('CsvView.Csv');
-	$this->set(compact('posts', '_serialize'));
+public function export()
+{
+    $posts = $this->Post->find('all');
+    $_serialize = null;
+    $this->viewBuilder()->className('CsvView.Csv');
+    $this->set(compact('posts', '_serialize'));
 }
 ```
 #### Setting a different encoding to the file
@@ -240,17 +253,18 @@ To set a custom file name, use the [`Response::download`](http://book.cakephp.or
 The following snippet can be used to change the downloaded file from `export.csv` to `my_file.csv`:
 
 ```php
-public function export() {
-	$data = [
-		['a', 'b', 'c'],
-		[1, 2, 3],
-		['you', 'and', 'me'],
-	];
-	$_serialize = 'data';
+public function export()
+{
+    $data = [
+        ['a', 'b', 'c'],
+        [1, 2, 3],
+        ['you', 'and', 'me'],
+    ];
+    $_serialize = 'data';
 
-	$this->response->download('my_file.csv'); // <= setting the file name
-	$this->viewBuilder()->className('CsvView.Csv');
-	$this->set(compact('data', '_serialize'));
+    $this->response->download('my_file.csv'); // <= setting the file name
+    $this->viewBuilder()->className('CsvView.Csv');
+    $this->set(compact('data', '_serialize'));
 }
 ```
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,17 +29,11 @@
         </listener>
     </listeners>
 
-    <!-- Prevent coverage reports from looking in tests and vendors -->
     <filter>
-        <blacklist>
-            <directory suffix=".php">./config/</directory>
-
-            <directory suffix=".php">./vendor/</directory>
-            <directory suffix=".ctp">./vendor/</directory>
-
-            <directory suffix=".php">./tests/</directory>
-            <directory suffix=".ctp">./tests/</directory>
-        </blacklist>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+            <directory suffix=".ctp">./src/</directory>
+        </whitelist>
     </filter>
 
 </phpunit>

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -337,10 +337,10 @@ class CsvView extends View
                         throw new Exception('Extractor must be a string or callable');
                     }
 
-                    if (isset($value)) {
-                        $values[] = sprintf($format, $value);
+                    if ($value === null) {
+                        $values[] = $value;
                     } else {
-                        $values[] = $this->viewVars['_null'];
+                        $values[] = sprintf($format, $value);
                     }
                 }
                 $this->_renderRow($values);
@@ -382,6 +382,10 @@ class CsvView extends View
     {
         static $fp = false;
 
+        if (empty($row)) {
+            return '';
+        }
+
         if ($fp === false) {
             $fp = fopen('php://temp', 'r+');
 
@@ -393,10 +397,6 @@ class CsvView extends View
             }
         } else {
             ftruncate($fp, 0);
-        }
-
-        if ($row === false || $row === null) {
-            return '';
         }
 
         if ($this->viewVars['_null'] !== '') {

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -303,26 +303,31 @@ class CsvView extends View
 
                 if ($extract === null) {
                     $this->_renderRow($_data);
-                } else {
-                    $values = [];
-                    foreach ($extract as $e) {
-                        list($formatter, $format) = $e;
-                        if (is_string($formatter)) {
-                            $value = Hash::get($_data, $formatter);
-                        } elseif (is_callable($formatter)) {
-                            $value = $formatter($_data);
-                        } else {
-                            throw new Exception('Extractor must be a string or callable');
-                        }
-
-                        if (isset($value)) {
-                            $values[] = sprintf($format, $value);
-                        } else {
-                            $values[] = $this->viewVars['_null'];
-                        }
-                    }
-                    $this->_renderRow($values);
+                    continue;
                 }
+
+                $values = [];
+                foreach ($extract as $e) {
+                    list($formatter, $format) = $e;
+                    if (is_string($formatter)) {
+                        if (strpos($formatter, '.') === false) {
+                            $value = $_data[$formatter];
+                        } else {
+                            $value = Hash::get($_data, $formatter);
+                        }
+                    } elseif (is_callable($formatter)) {
+                        $value = $formatter($_data);
+                    } else {
+                        throw new Exception('Extractor must be a string or callable');
+                    }
+
+                    if (isset($value)) {
+                        $values[] = sprintf($format, $value);
+                    } else {
+                        $values[] = $this->viewVars['_null'];
+                    }
+                }
+                $this->_renderRow($values);
             }
         }
     }

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -29,9 +29,12 @@ use Exception;
  *
  * ```
  * $_extract = [
- *   array('Post.id', '%d'),   // Hash-compatible path, sprintf-compatible format
- *   array('Post.title'),      // Uses `%s` for sprintf-formatting
- *   'Post.description',       // Uses `%s` for sprintf-formatting
+ *   [id', '%d'],       // Hash-compatible path, sprintf-compatible format
+ *   ['title'],         // Uses `%s` for sprintf-formatting
+ *   'description',     // Uses `%s` for sprintf-formatting
+ *   function ($row) {  // Uses `%s` for sprintf-formatting
+ *      //return value
+ *   }
  * ];
  * ```
  *
@@ -54,7 +57,7 @@ use Exception;
  * - array `$_footer`: (default null)    A flat array of footer column names
  * - string `$_delimiter`: (default ',') CSV Delimiter, defaults to comma
  * - string `$_enclosure`: (default '"') CSV Enclosure for use with fputscsv()
- * - string `$_eol`: (default '\n')       End-of-line character the csv
+ * - string `$_eol`: (default '\n')      End-of-line character the csv
  *
  * @link https://github.com/friendsofcake/cakephp-csvview
  */
@@ -83,7 +86,18 @@ class CsvView extends View
      */
     protected $_resetStaticVariables = false;
 
+    /**
+     * Iconv extension.
+     *
+     * @var string
+     */
     const EXTENSION_ICONV = 'iconv';
+
+    /**
+     * Mbstring extension.
+     *
+     * @var string
+     */
     const EXTENSION_MBSTRING = 'mbstring';
 
     /**
@@ -194,14 +208,16 @@ class CsvView extends View
      *
      * - array '_header': (default null)  A flat array of header column names
      * - array '_footer': (default null)  A flat array of footer column names
-     * - array '_extract': (default null) An array of Hash-compatible 'paths' with
-     *                                    matching 'sprintf' $format as follows:
+     * - array '_extract': (default null) An array of Hash-compatible paths or
+     *                                    callable with matching 'sprintf'
+     *                                    $format as follows:
      *
-     *                                    $_extract = array(
-     *                                      array($path, $format),
-     *                                      array($path),
-     *                                      $path,
-     *                                    );
+     *                                    $_extract = [
+     *                                        [$path, $format],
+     *                                        [$path],
+     *                                        $path,
+     *                                        function () { ... } // Callable
+     *                                    ];
      *
      *                                    If a string or unspecified, the format
      *                                    default is '%s'.

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -306,8 +306,15 @@ class CsvView extends View
                 } else {
                     $values = [];
                     foreach ($extract as $e) {
-                        list($path, $format) = $e;
-                        $value = Hash::get($_data, $path);
+                        list($formatter, $format) = $e;
+                        if (is_string($formatter)) {
+                            $value = Hash::get($_data, $formatter);
+                        } elseif (is_callable($formatter)) {
+                            $value = $formatter($_data);
+                        } else {
+                            throw new Exception('Extractor must be a string or callable');
+                        }
+
                         if (isset($value)) {
                             $values[] = sprintf($format, $value);
                         } else {

--- a/tests/TestCase/View/CsvViewTest.php
+++ b/tests/TestCase/View/CsvViewTest.php
@@ -279,36 +279,6 @@ class CsvViewTest extends TestCase
     }
 
     /**
-     * CsvViewTest::testRenderViaExtractException()
-     *
-     * @expectedException Exception
-     * @expectedExceptionMessage Extractor must be a string or callable
-     * @return void
-     */
-    public function testRenderViaExtractException()
-    {
-        $this->view->name = $this->view->viewPath = 'Posts';
-
-        $data = [
-            [
-                'username' => 'jose',
-                'created' => new Time('2010-01-05'),
-                'item' => [
-                    'name' => 'beach',
-                ]
-            ]
-        ];
-        $_extract = [
-            'username',
-            'created',
-            [$this, 'non-existent']
-        ];
-        $this->view->set(['user' => $data, '_extract' => $_extract]);
-        $this->view->set(['_serialize' => 'user']);
-        $output = $this->view->render(false);
-    }
-
-    /**
      * CsvViewTest::testRenderWithSpecialCharacters()
      *
      * @return void

--- a/tests/TestCase/View/CsvViewTest.php
+++ b/tests/TestCase/View/CsvViewTest.php
@@ -213,7 +213,8 @@ class CsvViewTest extends TestCase
         $data = [
             [
                 'User' => [
-                    'username' => 'jose'
+                    'id' => 1,
+                    'username' => 'jose',
                 ],
                 'Item' => [
                     'type' => 'beach',
@@ -221,6 +222,7 @@ class CsvViewTest extends TestCase
             ],
             [
                 'User' => [
+                    'id' => 2,
                     'username' => 'drew'
                 ],
                 'Item' => [
@@ -229,12 +231,12 @@ class CsvViewTest extends TestCase
                 ]
             ]
         ];
-        $_extract = ['User.username', 'Item.name', 'Item.type'];
+        $_extract = [['User.id', '%d'], 'User.username', 'Item.name', 'Item.type'];
         $this->view->set(['user' => $data, '_extract' => $_extract]);
         $this->view->set(['_serialize' => 'user']);
         $output = $this->view->render(false);
 
-        $this->assertSame('jose,,beach' . PHP_EOL . 'drew,ball,fun' . PHP_EOL, $output);
+        $this->assertSame('1,jose,,beach' . PHP_EOL . '2,drew,ball,fun' . PHP_EOL, $output);
         $this->assertSame('text/csv', $this->response->type());
     }
 

--- a/tests/TestCase/View/CsvViewTest.php
+++ b/tests/TestCase/View/CsvViewTest.php
@@ -239,6 +239,76 @@ class CsvViewTest extends TestCase
     }
 
     /**
+     * CsvViewTest::testRenderViaExtractWithCallable()
+     *
+     * @return void
+     */
+    public function testRenderViaExtractWithCallable()
+    {
+        $this->view->name = $this->view->viewPath = 'Posts';
+
+        $data = [
+            [
+                'username' => 'jose',
+                'created' => new Time('2010-01-05'),
+                'item' => [
+                    'name' => 'beach',
+                ]
+            ],
+            [
+                'username' => 'drew',
+                'created' => null,
+                'item' => [
+                    'name' => 'ball',
+                ]
+            ]
+        ];
+        $_extract = [
+            'username',
+            'created',
+            function ($row) {
+                return 'my-' . $row['item']['name'];
+            }
+        ];
+        $this->view->set(['user' => $data, '_extract' => $_extract]);
+        $this->view->set(['_serialize' => 'user']);
+        $output = $this->view->render(false);
+
+        $this->assertSame('jose,"2010-01-05 00:00:00",my-beach' . PHP_EOL . 'drew,,my-ball' . PHP_EOL, $output);
+        $this->assertSame('text/csv', $this->response->type());
+    }
+
+    /**
+     * CsvViewTest::testRenderViaExtractException()
+     *
+     * @expectedException Exception
+     * @expectedExceptionMessage Extractor must be a string or callable
+     * @return void
+     */
+    public function testRenderViaExtractException()
+    {
+        $this->view->name = $this->view->viewPath = 'Posts';
+
+        $data = [
+            [
+                'username' => 'jose',
+                'created' => new Time('2010-01-05'),
+                'item' => [
+                    'name' => 'beach',
+                ]
+            ]
+        ];
+        $_extract = [
+            'username',
+            'created',
+            [$this, 'non-existent']
+        ];
+        $this->view->set(['user' => $data, '_extract' => $_extract]);
+        $this->view->set(['_serialize' => 'user']);
+        $output = $this->view->render(false);
+    }
+
+    /**
      * CsvViewTest::testRenderWithSpecialCharacters()
      *
      * @return void


### PR DESCRIPTION
- Added support for using a callable in `$_extract`.
- Removed unnecessary use of `sprintf()` for all values. All values are going to be implicitly converted to string anyway. `sprintf()` will be now used only when for format like `[$hashPath, $sprintfFormat]`. While this change is unlikely to affect existing users we can bump minor version of the plugin to be safe.