### PR TITLE
Add BOM handling for all platforms

### DIFF
--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -465,12 +465,13 @@ class CsvView extends View
     /**
      * Returns the BOM for the encoding given.
      *
-     * @param string $csvEncoding
+     * @param string $csvEncoding The encoding you want the BOM for
      * @return string
      */
     protected function getBom($csvEncoding)
     {
         $csvEncoding = strtoupper($csvEncoding);
+
         return isset($this->bomMap[$csvEncoding]) ? $this->bomMap[$csvEncoding] : '';
     }
 }

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -455,7 +455,7 @@ class CsvView extends View
         }
 
         //bom must be added after encoding
-        if ($this->viewVars['_bom'] === true) {
+        if ($this->viewVars['_bom'] == true) {
             $csv = $this->getBom($this->viewVars['_csvEncoding']) . $csv;
         }
 

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -101,6 +101,7 @@ class CsvView extends View
 
     /**
      * List of bom signs for encodings.
+     *
      * @var array
      */
     protected $bomMap;

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -455,7 +455,7 @@ class CsvView extends View
         }
 
         //bom must be added after encoding
-        if ($this->viewVars['_bom'] == true) {
+        if ($this->viewVars['_bom']) {
             $csv = $this->getBom($this->viewVars['_csvEncoding']) . $csv;
         }
 

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -103,7 +103,7 @@ class CsvView extends View
      * List of bom signs for encodings.
      * @var array
      */
-    private $BOM_MAP;
+    protected $bomMap;
 
     /**
      * List of special view vars.
@@ -141,7 +141,7 @@ class CsvView extends View
         EventManager $eventManager = null,
         array $viewOptions = []
     ) {
-        $this->BOM_MAP = [
+        $this->bomMap = [
             'UTF-32BE' => chr(0x00) . chr(0x00) . chr(0xFE) . chr(0xFF),
             'UTF-32LE' => chr(0xFF) . chr(0xFE) . chr(0x00) . chr(0x00),
             'UTF-16BE' => chr(0xFE) . chr(0xFF),
@@ -463,12 +463,12 @@ class CsvView extends View
 
     /**
      * Returns the BOM for the encoding given.
-     * @param $csvEncoding
+     * @param string $csvEncoding
      * @return string
      */
-    private function getBom($csvEncoding)
+    protected function getBom($csvEncoding)
     {
         $csvEncoding = strtoupper($csvEncoding);
-        return array_key_exists($csvEncoding, $this->BOM_MAP) ? $this->BOM_MAP[$csvEncoding] : '';
+        return isset($this->bomMap[$csvEncoding]) ? $this->bomMap[$csvEncoding] : '';
     }
 }

--- a/src/View/CsvView.php
+++ b/src/View/CsvView.php
@@ -464,6 +464,7 @@ class CsvView extends View
 
     /**
      * Returns the BOM for the encoding given.
+     *
      * @param string $csvEncoding
      * @return string
      */

--- a/tests/TestCase/View/CsvViewTest.php
+++ b/tests/TestCase/View/CsvViewTest.php
@@ -42,6 +42,27 @@ class CsvViewTest extends TestCase
     }
 
     /**
+     * testBom method
+     *
+     * @return void
+     */
+    public function testBom()
+    {
+        if (!extension_loaded('mbstring')) {
+            $this->markTestSkipped(
+                'The mbstring extension is not available.'
+            );
+        }
+
+        $data = [['test']];
+        $this->view->set(['data' => $data, '_serialize' => 'data', '_bom' => true, '_csvEncoding' => 'UTF-16LE']);
+        $output = $this->view->render(false);
+
+        $expected = chr(0xFF) . chr(0xFE) . mb_convert_encoding('test' . PHP_EOL, 'UTF-16LE', 'UTF-8');
+        $this->assertSame($expected, $output);
+    }
+
+    /**
      * Test render with an array in _serialize
      *
      * @return void


### PR DESCRIPTION
iconv doesn't add a BOM in all cases (especially when endianess is given e.g. `iconv("UTF-8","UTF-16LE","a")`). So I had to add a mapping (from http://unicode.org/faq/utf_bom.html#bom3) and prepend the BOM manually.

Also added a test that shows the behavior.