### PR TITLE
Enabling plugin in CakePHP version 3.5 or newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Load the plugin in your app's `config/bootstrap.php` file:
 
 	Plugin::load('CsvView');
 
+In CakePHP version 3.5 or newer you should use:
+
+    Plugin::load('CsvView', ['routes' => true]);
+
 ## Usage
 
 To export a flat array as a CSV, one could write the following code:


### PR DESCRIPTION
Resolves problems with plugin load in CakePHP from version 3.5. Mentioned in #87 .