### PR TITLE
Fix type hinting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ public function export()
     $_header = ['Post ID', 'Title', 'Created'];
     $_extract = [
         'id',
-        function (\App\Model\Entity\Post $row) {
-            return $row->title;
+        function (array $row) {
+            return $row['title'];
         },
         'created'
     ];


### PR DESCRIPTION
Currently, it seems that Entity is not passed to function.
I modified type hinting described in README to array.

https://github.com/FriendsOfCake/cakephp-csvview/blob/3.3.2/src/View/CsvView.php#L332